### PR TITLE
Use react-native-webview@^5.8.2/WebView instead of deprecated react-native/WebView

### DIFF
--- a/AutoResizeHeightWebView.js
+++ b/AutoResizeHeightWebView.js
@@ -3,7 +3,8 @@
  */
 
 import React, { Component } from 'react';
-import {StyleSheet, View, WebView , Animated} from 'react-native';
+import {StyleSheet, View, Animated} from 'react-native';
+import {WebView} from 'react-native-webview';
 
 let Dimensions = require('Dimensions');
 let {width, height} = Dimensions.get('window');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "16.0.0",
     "react-native": "0.51.0",
     "react-native-image-zoom-viewer": "^2.0.16",
+    "react-native-webview": "^5.8.2",
     "react-navigation": "^1.0.0-beta.22"
   },
   "devDependencies": {

--- a/react-native-autoreheight-webview/AutoResizeHeightWebView.js
+++ b/react-native-autoreheight-webview/AutoResizeHeightWebView.js
@@ -3,7 +3,8 @@
  */
 
 import React, { Component } from 'react';
-import {StyleSheet, View, WebView , Animated} from 'react-native';
+import {StyleSheet, View , Animated} from 'react-native';
+import {WebView} from "react-native-webview";
 
 //modify webview error:  https://github.com/facebook/react-native/issues/10865
 const patchPostMessageJsCode = `


### PR DESCRIPTION
react-native/WebView is [soon to be deprecated and removed from RN core.](https://github.com/react-native-community/discussions-and-proposals/pull/3).

While using latest react-native@0.59.8 console warnings appear saying WebView is extracted from react-native to a stand-alone npm package [react-native-webview](https://github.com/react-native-community/react-native-webview).

![image](https://user-images.githubusercontent.com/4222159/57774939-7eb79800-7724-11e9-96e4-29f282030d8a.png)

This pull request contains the small changes to start using react-native-webview


